### PR TITLE
add multi device support and tool sanity checking

### DIFF
--- a/adb-record-gif.sh
+++ b/adb-record-gif.sh
@@ -24,7 +24,7 @@ fi
 
 function finish {
   sleep 1
-  echo "\nPulling file..."
+  echo "Pulling file..."
   adb -s $device pull $filename
   adb -s $device shell rm $filename
 
@@ -37,7 +37,7 @@ function finish {
   echo "Done!"
 }
 
-trap finish EXIT
+trap finish SIGINT
 
-echo "Recording $filename... Press Ctrl + C to end the recording"
+printf "Recording $filename...\nPress Ctrl + C to end the recording\n"
 adb -s $device shell screenrecord $filename

--- a/adb-record-gif.sh
+++ b/adb-record-gif.sh
@@ -1,14 +1,32 @@
 #!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 
+if ! command -v adb > /dev/null; then
+    echo "Missing adb";
+    exit 1
+fi
+if ! command -v ffmpeg  > /dev/null; then
+    echo "Missing ffmpeg";
+    exit 1
+fi
+
 timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
 filename="/sdcard/$timestamp.mp4"
+if [ -z $1 ]; then
+    device=$(adb devices | grep '^.\+\sdevice$' | head -1 | cut -f 1)
+    if [ -z $device ]; then
+        echo "Could not find a device"
+        exit 1
+    fi
+else
+    device=$1
+fi
 
 function finish {
   sleep 1
   echo "\nPulling file..."
-  adb pull $filename
-  adb shell rm $filename
+  adb -s $device pull $filename
+  adb -s $device shell rm $filename
 
   echo "Making gif!"
   ffmpeg -y -i "$timestamp.mp4" -vf "fps=30,scale=640:-1:flags=lanczos,palettegen" palette.png
@@ -22,6 +40,4 @@ function finish {
 trap finish EXIT
 
 echo "Recording $filename... Press Ctrl + C to end the recording"
-adb shell screenrecord $filename
-
-
+adb -s $device shell screenrecord $filename


### PR DESCRIPTION
I had multiple devices connected, this caused none of the adb functions to run
made it optional to specify the device, otherwise picking the first on the `adb devices` list

I also didn't have `adb` in my path initially so it failed there as well, so i added checks
