### PR TITLE
Using ENV-var instead of flag in case of no input.

### DIFF
--- a/adb-record-gif.sh
+++ b/adb-record-gif.sh
@@ -12,21 +12,22 @@ fi
 
 timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
 filename="/sdcard/$timestamp.mp4"
+
 if [ -z $1 ]; then
-    device=$(adb devices | grep '^.\+\sdevice$' | head -1 | cut -f 1)
-    if [ -z $device ]; then
+    export ANDROID_SERIAL=$(adb devices | grep '^.\+\sdevice$' | head -1 | cut -f 1)
+    if [ -z $ANDROID_SERIAL ]; then
         echo "Could not find a device"
         exit 1
     fi
 else
-    device=$1
+    export ANDROID_SERIAL=$1
 fi
 
 function finish {
   sleep 1
-  echo "\nPulling file..."
-  adb -s $device pull $filename
-  adb -s $device shell rm $filename
+  echo "Pulling file..."
+  adb pull $filename
+  adb shell rm $filename
 
   echo "Making gif!"
   ffmpeg -y -i "$timestamp.mp4" -vf "fps=30,scale=640:-1:flags=lanczos,palettegen" palette.png
@@ -37,7 +38,7 @@ function finish {
   echo "Done!"
 }
 
-trap finish EXIT
+trap finish SIGINT
 
-echo "Recording $filename... Press Ctrl + C to end the recording"
-adb -s $device shell screenrecord $filename
+printf "Recording $filename...\nPress Ctrl + C to end the recording\n"
+adb shell screenrecord $filename


### PR DESCRIPTION
- Changed trap from EXIT to SIGINT in order to only run `finish()` when user interrupts. Had issue with errors caused by low API-versions - those without support for screen recordings.

- Running the script without specifying device ( no $1 arg ) caused error since the `-s` flag was still there and that caused an interpretation of "shell" as device. Exporting ANDROID_SERIAL instead solved it.