### PR TITLE
Fixed OS X specific mktemp issue

### DIFF
--- a/adb-screen-capture.sh
+++ b/adb-screen-capture.sh
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 workdir=$(pwd)
-tmpdir=$(mktemp -d -p "$workdir")
+tmpdir=$(mktemp -d)
 timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
 
 margin=50
@@ -18,7 +18,7 @@ function finish {
 
   popd
   
-  mv "$tmpdir/$timestamp.png" $workdir
+  mv "$tmpdir/$timestamp.png" .
   rm -rf "$tmpdir"
 }
 


### PR DESCRIPTION
In OS X you don't have the `-p` option, and we don't really need it...

```
-p DIR              use DIR as a prefix; implies -t [deprecated]
```
☝️ https://www.gnu.org/software/autogen/mktemp.html